### PR TITLE
Allow to not move processed files and not to specify processed_dir in settings

### DIFF
--- a/lib/file_loaders/adapters/file.rb
+++ b/lib/file_loaders/adapters/file.rb
@@ -14,14 +14,14 @@ module FileLoaders
         raise(
           ArgumentError,
           "Processed reports directory #{@processed_dir} does not exists"
-        ) unless Dir.exist?(@processed_dir)
+        ) if @processed_dir && !Dir.exist?(@processed_dir)
       end
 
       def each
         Dir[*paths].entries.each do |entry|
           basename = ::File.basename(entry)
 
-          if yield(entry, entry)
+          if yield(entry, entry) && @processed_dir
             processed_path = "#{@processed_dir}/#{basename}"
             FileUtils.mv entry, processed_path
           end

--- a/lib/file_loaders/adapters/sftp.rb
+++ b/lib/file_loaders/adapters/sftp.rb
@@ -38,6 +38,7 @@ module FileLoaders
       end
 
       def move_to_processed(sftp, entry)
+        return if settings.processed_dir.nil?
         processed_path = ::File.join(settings.processed_dir, ::File.basename(entry))
         sftp.remove(processed_path)
         sftp.rename!(entry, processed_path)

--- a/lib/file_loaders/adapters/sftp.rb
+++ b/lib/file_loaders/adapters/sftp.rb
@@ -1,4 +1,5 @@
 require 'net/sftp'
+require 'tmpdir'
 
 module FileLoaders
   module Adapters
@@ -45,7 +46,7 @@ module FileLoaders
       end
 
       def make_tempdir
-        "/tmp/#{Dir::Tmpname.make_tmpname('sftp', nil)}".tap do |name|
+        Dir::Tmpname.create('sftp') do |name, *|
           FileUtils.mkdir_p name
         end
       end

--- a/spec/adapters/file_spec.rb
+++ b/spec/adapters/file_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe FileLoaders::Adapters::File do
 
   before do
     FileUtils.mkdir_p(source_dir)
-    FileUtils.mkdir_p(processed_dir)
+    FileUtils.mkdir_p(processed_dir) if processed_dir
 
     files.each { |path| File.write(path, "Content of #{path}") }
   end
 
   after do
-    FileUtils.rm_rf(processed_dir)
+    FileUtils.rm_rf(processed_dir) if processed_dir
     FileUtils.rm_rf(source_dir)
   end
 
@@ -41,6 +41,18 @@ RSpec.describe FileLoaders::Adapters::File do
     )
   end
   # rubocop: enable RSpec/MultipleExpectations
+
+  context "when processed directory is unspecified" do
+    let(:settings) { Settings.new("tmp/purchase_reports_test", nil) }
+
+    it "doesn't move entries to processed directory" do
+      subject.each { true }
+
+      expect(Dir[File.join(source_dir, "*")]).to match_array(
+        FILES.map { |name| File.join(source_dir, name) }
+      )
+    end
+  end
 
   FILES = %w(example.csv example.json).freeze
 end

--- a/spec/adapters/sftp_spec.rb
+++ b/spec/adapters/sftp_spec.rb
@@ -66,4 +66,14 @@ RSpec.describe FileLoaders::Adapters::Sftp do
       expect(sftp).to have_received(:remove).with("#{processed_dir}/#{file}")
     end
   end
+
+  context "when processed directory is unspecified" do
+    let(:settings) { Settings.new("tmp/purchase_reports_test", nil) }
+
+    it "doesn't move entries to processed directory" do
+      subject.each { true }
+
+      expect(sftp).not_to have_received(:remove)
+    end
+  end
 end


### PR DESCRIPTION
Sometimes moving files is not desired.